### PR TITLE
Enable access to mpris dbus interface

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -15,6 +15,7 @@
     "--device=all",
     "--talk-name=org.freedesktop.PowerManagement",
     "--talk-name=org.freedesktop.ScreenSaver",
+    "--own-name=org.mpris.MediaPlayer2.mpv",
     "--system-talk-name=org.freedesktop.login1"
   ],
   "modules": [


### PR DESCRIPTION
Required to support mpris control in Flatpak via the [mpv-mpris](https://github.com/hoyon/mpv-mpris) module.