### PR TITLE
Update modules and add flatpak-external-data-checker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.json]
+indent_style = space
+indent_size = 2
+insert_final_newline = true

--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -37,37 +37,67 @@
         {
           "type": "git",
           "url": "https://github.com/iwalton3/jellyfin-media-player.git",
-          "commit": "086fd6a5217ffcb907fa6c34f9fbbc6f59bb4e60"
+          "tag": "v1.9.1",
+          "commit": "086fd6a5217ffcb907fa6c34f9fbbc6f59bb4e60",
+          "x-checker-data": {
+            "type": "git",
+            "tag-pattern": "^v([\\d.]+)$"
+          }
         },
         {
           "type": "archive",
-          "url": "https://repo.jellyfin.org/releases/server/portable/stable/web/jellyfin-web_10.8.10_portable.tar.gz",
-          "sha256": "d6145a247239fb9a9f2cc7e69549ca08b0c33878c0b249670fcc64d4dfb20552",
-          "dest": "dist"
+          "url": "https://repo.jellyfin.org/releases/server/portable/versions/stable/web/10.8.12/jellyfin-web_10.8.12_portable.tar.gz",
+          "sha256": "a0da090a98bd230c8fc718e8c3d648418a69c6cc3dc5a878af08689f578a3562",
+          "dest": "dist",
+          "x-checker-data": {
+            "type": "html",
+            "url": "https://repo.jellyfin.org/releases/server/portable/versions/stable/web/",
+            "version-pattern": "(\\d+\\.\\d+\\.\\d+)\\/",
+            "url-template": "https://repo.jellyfin.org/releases/server/portable/versions/stable/web/$version/jellyfin-web_${version}_portable.tar.gz"
+          }
         }
       ],
       "modules": [
         {
           "name": "mpv",
-          "only-arches": ["i386", "x86_64"],
-          "buildsystem": "simple",
-          "build-commands": [
-            "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-manpage-build --enable-vaapi --enable-cuda-hwaccel --enable-pulse --enable-alsa --disable-tv --enable-uchardet",
-            "python3 waf build",
-            "python3 waf install"
+          "buildsystem": "meson",
+          "config-opts": [
+            "-Dlibmpv=true",
+            "-Dcplayer=false",
+            "-Dbuild-date=false",
+            "-Dmanpage-build=disabled",
+            "-Dvaapi=enabled",
+            "-Dcuda-hwaccel=enabled",
+            "-Dpulse=enabled",
+            "-Dalsa=enabled",
+            "-Duchardet=enabled"
           ],
-          "cleanup": [ "/lib/pkgconfig", "/share", "/include" ],
+          "cleanup": [
+            "/lib/pkgconfig",
+            "/share",
+            "/include"
+          ],
           "sources": [
             {
-              "type": "archive",
-              "url": "https://github.com/mpv-player/mpv/archive/v0.35.1.tar.gz",
-              "sha256": "41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b387d1a9"
+              "type": "git",
+              "url": "https://github.com/mpv-player/mpv.git",
+              "tag": "v0.37.0",
+              "commit": "818ce7c51a6b9179307950e919983e0909942098",
+              "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\\d.]+)$"
+              }
             },
             {
               "type": "file",
-              "url": "https://waf.io/waf-2.0.25",
-              "sha256": "21199cd220ccf60434133e1fd2ab8c8e5217c3799199c82722543970dc8e38d5",
-              "dest-filename": "waf"
+              "url": "https://waf.io/waf-2.0.26",
+              "sha256": "dcec3e179f9c33a66544f1b3d7d91f20f6373530510fa6a858cddb6bfdcde14b",
+              "dest-filename": "waf",
+              "x-checker-data": {
+                "type": "anitya",
+                "project-id": 5116,
+                "url-template": "https://waf.io/waf-$version"
+              }
             }
           ],
           "modules": [
@@ -75,15 +105,22 @@
               "name": "ffnvcodec",
               "buildsystem": "simple",
               "build-commands": [
-                  "make install PREFIX=/app"
+                "make install PREFIX=/app"
               ],
-              "only-arches": ["i386", "x86_64"],
-              "cleanup": [ "/lib/pkgconfig", "/include" ],
+              "cleanup": [
+                "/lib/pkgconfig",
+                "/include"
+              ],
               "sources": [
                 {
-                  "type": "archive",
-                  "url": "https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.1.5.2/nv-codec-headers-11.1.5.2.tar.gz",
-                  "sha256": "1442e3159e7311dd71f8fca86e615f51609998939b6a6d405d6683d8eb3af6ee"
+                  "type": "git",
+                  "url": "https://github.com/FFmpeg/nv-codec-headers.git",
+                  "tag": "n12.1.14.0",
+                  "commit": "1889e62e2d35ff7aa9baca2bceb14f053785e6f1",
+                  "x-checker-data": {
+                    "type": "git",
+                    "tag-pattern": "^n([\\d.]+)$"
+                  }
                 }
               ]
             },
@@ -103,12 +140,23 @@
                 "--enable-cuvid",
                 "--enable-libdav1d"
               ],
-              "cleanup": [ "/lib/pkgconfig", "/share", "/include" ],
-              "sources": [{
-                "type": "archive",
-                "url": "https://ffmpeg.org/releases/ffmpeg-5.1.2.tar.xz",
-                "sha256": "619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc"
-              }]
+              "cleanup": [
+                "/lib/pkgconfig",
+                "/share",
+                "/include"
+              ],
+              "sources": [
+                {
+                  "type": "git",
+                  "url": "https://github.com/FFmpeg/FFmpeg.git",
+                  "tag": "n6.1",
+                  "commit": "d4ff0020b40b524a490cf62eccbd3a318f4c0e58",
+                  "x-checker-data": {
+                    "type": "git",
+                    "tag-pattern": "^n([\\d.]+)$"
+                  }
+                }
+              ]
             },
             "shared-modules/luajit/luajit.json",
             {
@@ -117,116 +165,21 @@
                 "--enable-shared",
                 "--disable-static"
               ],
-              "cleanup": [ "/lib/*.la", "/lib/pkgconfig", "/include" ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://github.com/libass/libass/releases/download/0.17.0/libass-0.17.0.tar.xz",
-                  "sha256": "971e2e1db59d440f88516dcd1187108419a370e64863f70687da599fdf66cc1a"
-                }
-              ]
-            },
-            {
-              "name": "uchardet",
-              "buildsystem": "cmake-ninja",
-              "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INSTALL_LIBDIR=lib",
-                "-DBUILD_BINARY=OFF"
-              ],
-              "cleanup": [ "/lib/*.a", "/lib/pkgconfig", "/share", "/include" ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz",
-                  "sha256": "e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "mpv",
-          "skip-arches": ["i386", "x86_64"],
-          "buildsystem": "simple",
-          "build-commands": [
-            "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-manpage-build --enable-vaapi --enable-pulse --enable-alsa --disable-tv --enable-uchardet",
-            "python3 waf build",
-            "python3 waf install"
-          ],
-          "cleanup": [ "/lib/pkgconfig", "/share", "/include" ],
-          "sources": [
-            {
-              "type": "archive",
-              "url": "https://github.com/mpv-player/mpv/archive/v0.35.1.tar.gz",
-              "sha256": "41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b387d1a9"
-            },
-            {
-              "type": "file",
-              "url": "https://waf.io/waf-2.0.25",
-              "sha256": "21199cd220ccf60434133e1fd2ab8c8e5217c3799199c82722543970dc8e38d5",
-              "dest-filename": "waf"
-            }
-          ],
-          "modules": [
-            {
-              "name": "ffmpeg",
-              "config-opts": [
-                "--enable-shared",
-                "--disable-static",
-                "--enable-gnutls",
-                "--enable-pic",
-                "--disable-doc",
-                "--disable-programs",
-                "--disable-encoders",
-                "--disable-muxers",
-                "--disable-devices",
-                "--enable-vaapi",
-                "--enable-libdav1d"
-              ],
-              "cleanup": [ "/lib/pkgconfig", "/share", "/include" ],
-              "sources": [{
-                "type": "archive",
-                "url": "https://ffmpeg.org/releases/ffmpeg-5.1.2.tar.xz",
-                "sha256": "619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc"
-              }]
-            },
-            {
-              "name": "luajit",
-              "no-autogen": true,
               "cleanup": [
-                "/bin",
-                "/lib/*.a",
-                "/include",
+                "/lib/*.la",
                 "/lib/pkgconfig",
-                "/share/man"
+                "/include"
               ],
               "sources": [
                 {
-                  "type": "archive",
-                  "url": "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
-                  "sha256": "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-                },
-                {
-                  "type": "shell",
-                  "commands": [
-                    "sed -i 's|/usr/local|/app|' ./Makefile"
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "libass",
-              "config-opts": [
-                "--enable-shared",
-                "--disable-static"
-              ],
-              "cleanup": [ "/lib/*.la", "/lib/pkgconfig", "/include" ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://github.com/libass/libass/releases/download/0.17.0/libass-0.17.0.tar.xz",
-                  "sha256": "971e2e1db59d440f88516dcd1187108419a370e64863f70687da599fdf66cc1a"
+                  "type": "git",
+                  "url": "https://github.com/libass/libass.git",
+                  "tag": "0.17.1",
+                  "commit": "e8ad72accd3a84268275a9385beb701c9284e5b3",
+                  "x-checker-data": {
+                    "type": "git",
+                    "tag-pattern": "^([\\d.]+)$"
+                  }
                 }
               ]
             },
@@ -238,12 +191,110 @@
                 "-DCMAKE_INSTALL_LIBDIR=lib",
                 "-DBUILD_BINARY=OFF"
               ],
-              "cleanup": [ "/lib/*.a", "/lib/pkgconfig", "/share", "/include" ],
+              "cleanup": [
+                "/lib/*.a",
+                "/lib/pkgconfig",
+                "/share",
+                "/include"
+              ],
               "sources": [
                 {
                   "type": "archive",
                   "url": "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz",
-                  "sha256": "e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0"
+                  "sha256": "e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0",
+                  "x-checker-data": {
+                    "type": "html",
+                    "url": "https://www.freedesktop.org/software/uchardet/releases/",
+                    "version-pattern": "uchardet-(\\d+\\.\\d+\\.\\d+)\\.tar\\.xz",
+                    "url-template": "https://www.freedesktop.org/software/uchardet/releases/uchardet-$version.tar.xz"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "libplacebo",
+              "buildsystem": "meson",
+              "config-opts": [
+                "-Dvulkan=enabled",
+                "-Dshaderc=enabled"
+              ],
+              "cleanup": [
+                "/include",
+                "/lib/pkgconfig"
+              ],
+              "sources": [
+                {
+                  "type": "git",
+                  "url": "https://code.videolan.org/videolan/libplacebo.git",
+                  "tag": "v6.338.1",
+                  "commit": "2805a0d01c029084ab36bf5d0e3c8742012a0b27",
+                  "x-checker-data": {
+                    "type": "git",
+                    "tag-pattern": "^v([\\d.]+)$"
+                  }
+                }
+              ],
+              "modules": [
+                {
+                  "name": "shaderc",
+                  "buildsystem": "cmake-ninja",
+                  "builddir": true,
+                  "config-opts": [
+                    "-DSHADERC_SKIP_COPYRIGHT_CHECK=ON",
+                    "-DSHADERC_SKIP_EXAMPLES=ON",
+                    "-DSHADERC_SKIP_TESTS=ON",
+                    "-DSPIRV_SKIP_EXECUTABLES=ON",
+                    "-DENABLE_GLSLANG_BINARIES=OFF",
+                    "-DCMAKE_BUILD_TYPE=Release"
+                  ],
+                  "cleanup": [
+                    "/bin",
+                    "/include",
+                    "/lib/*.a",
+                    "/lib/cmake",
+                    "/lib/pkgconfig"
+                  ],
+                  "sources": [
+                    {
+                      "type": "git",
+                      "url": "https://github.com/google/shaderc.git",
+                      "tag": "v2023.7",
+                      "commit": "3882b16417077aa8eaa7b5775920e7ba4b8a224d",
+                      "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                      }
+                    },
+                    {
+                      "type": "git",
+                      "url": "https://github.com/KhronosGroup/SPIRV-Tools.git",
+                      "tag": "v2023.2",
+                      "commit": "44d72a9b36702f093dd20815561a56778b2d181e",
+                      "dest": "third_party/spirv-tools",
+                      "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                      }
+                    },
+                    {
+                      "type": "git",
+                      "url": "https://github.com/KhronosGroup/SPIRV-Headers.git",
+                      "tag": "sdk-1.3.250.1",
+                      "commit": "268a061764ee69f09a477a695bf6a11ffe311b8d",
+                      "dest": "third_party/spirv-headers"
+                    },
+                    {
+                      "type": "git",
+                      "url": "https://github.com/KhronosGroup/glslang.git",
+                      "tag": "13.1.1",
+                      "commit": "36d08c0d940cf307a23928299ef52c7970d8cee6",
+                      "dest": "third_party/glslang",
+                      "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                      }
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
Adds [flatpak-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) for automated PRs to keep modules up to date. Also updates all modules, including mpv, which now has new required dependencies, so those new dependencies were added.

I have been using this branch for a bit over a week, and haven't found any issues with the updated modules.