### PR TITLE
Downgrade mpv to v0.36.0

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -81,12 +81,8 @@
             {
               "type": "git",
               "url": "https://github.com/mpv-player/mpv.git",
-              "tag": "v0.37.0",
-              "commit": "818ce7c51a6b9179307950e919983e0909942098",
-              "x-checker-data": {
-                "type": "git",
-                "tag-pattern": "^v([\\d.]+)$"
-              }
+              "tag": "v0.36.0",
+              "commit": "f4210f84906c3b00a65fba198c8127b6757b9350"
             },
             {
               "type": "file",


### PR DESCRIPTION
Fixes #18 

Some options that were previously deprecated are removed in v0.37.0, unsure if this is the cause of the issues or if there was some other change:

2023-12-11 09:28:33.732 [warning] unknown @ 0 - cplayer: Warning: option --af-defaults is deprecated and might be removed in the future (use --af + enable/disable flags).
2023-12-11 09:28:33.732 [warning] unknown @ 0 - cplayer: Option af-del: -del is deprecated! Use -remove (removes by content instead of by index).
2023-12-11 09:28:33.732 [warning] unknown @ 0 - cplayer: Setting the display-fps property is deprecated; set the override-display-fps property instead.
2023-12-11 09:28:33.732 [warning] unknown @ 0 - cplayer: Warning: property 'video-aspect' is deprecated, refer to 'video-params/aspect' and 'video-aspect-override'.
2023-12-11 09:28:35.599 [warning] unknown @ 0 - cplayer: Setting the display-fps property is deprecated; set the override-display-fps property instead.