### PR TITLE
Add --enable-gpl to ffmpeg build options

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -138,7 +138,8 @@
                 "--disable-devices",
                 "--enable-vaapi",
                 "--enable-cuvid",
-                "--enable-libdav1d"
+                "--enable-libdav1d",
+                "--enable-gpl"
               ],
               "cleanup": [
                 "/lib/pkgconfig",


### PR DESCRIPTION
enables gpl on ffmpeg build due to it being a dependency of various filters (e.g cropdetect), allowing mpv scripts that use the those filters filter to work (e.g a dynamic aspect ratio crop script)
fixes #27