### PR TITLE
Remove waf

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -87,17 +87,6 @@
                 "type": "git",
                 "tag-pattern": "^v([\\d.]+)$"
               }
-            },
-            {
-              "type": "file",
-              "url": "https://waf.io/waf-2.0.26",
-              "sha256": "dcec3e179f9c33a66544f1b3d7d91f20f6373530510fa6a858cddb6bfdcde14b",
-              "dest-filename": "waf",
-              "x-checker-data": {
-                "type": "anitya",
-                "project-id": 5116,
-                "url-template": "https://waf.io/waf-$version"
-              }
             }
           ],
           "modules": [


### PR DESCRIPTION
waf was previously used for building mpv, but was removed and replaced with meson, so it is no longer needed.