### PR TITLE
Fix filename for jellyfin-server version checker

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -47,8 +47,8 @@
           "x-checker-data": {
             "type": "html",
             "url": "https://repo.jellyfin.org/files/server/portable/latest/any/",
-            "version-pattern": "jellyfin_(\\d+\\.\\d+\\.\\d+).tar.gz.gz",
-            "url-template": "https://repo.jellyfin.org/files/server/portable/latest/any/jellyfin_${version}.tar.gz.gz"
+            "version-pattern": "jellyfin_(\\d+\\.\\d+\\.\\d+).tar.gz",
+            "url-template": "https://repo.jellyfin.org/files/server/portable/latest/any/jellyfin_${version}.tar.gz"
           }
         },
         {


### PR DESCRIPTION
Filename had .gz.gz as the file extension