### PR TITLE
Reduce permissions

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -12,7 +12,7 @@
     "--socket=pulseaudio",
     "--share=ipc",
     "--share=network",
-    "--device=all",
+    "--device=dri",
     "--talk-name=org.freedesktop.PowerManagement",
     "--talk-name=org.freedesktop.ScreenSaver",
     "--own-name=org.mpris.MediaPlayer2.mpv",


### PR DESCRIPTION
This change reduces the permissions advertised on flathub to a less scary subset needed for rendering. This has been tested on Ubuntu 24.04 using non-free NVIDIA drivers and Wayland as described in https://github.com/flathub/com.github.iwalton3.jellyfin-media-player/issues/67