### PR TITLE
Update runtime to 5.15-24.08, update components

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -17,6 +17,7 @@
     "mkdir -p /app/lib/ffmpeg"
   ],
   "finish-args": [
+    "--socket=wayland",
     "--socket=fallback-x11",
     "--socket=pulseaudio",
     "--share=ipc",

--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -1,275 +1,196 @@
 {
   "app-id": "com.github.iwalton3.jellyfin-media-player",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15-23.08",
+  "runtime-version": "5.15-24.08",
   "sdk": "org.kde.Sdk",
   "base": "io.qt.qtwebengine.BaseApp",
-  "base-version": "5.15-23.08",
+  "base-version": "5.15-24.08",
   "command": "jellyfinmediaplayer",
+  "add-extensions": {
+      "org.freedesktop.Platform.ffmpeg-full": {
+          "directory": "lib/ffmpeg",
+          "version": "24.08",
+          "add-ld-path": "."
+      }
+  },
+  "cleanup-commands": [
+      "mkdir -p /app/lib/ffmpeg"
+  ],
   "finish-args": [
-    "--socket=fallback-x11",
-    "--socket=wayland",
-    "--socket=pulseaudio",
-    "--share=ipc",
-    "--share=network",
-    "--device=all",
-    "--talk-name=org.freedesktop.PowerManagement",
-    "--talk-name=org.freedesktop.ScreenSaver",
-    "--own-name=org.mpris.MediaPlayer2.mpv",
-    "--system-talk-name=org.freedesktop.login1"
+      "--socket=fallback-x11",
+      "--socket=wayland",
+      "--socket=pulseaudio",
+      "--share=ipc",
+      "--share=network",
+      "--device=all",
+      "--talk-name=org.freedesktop.PowerManagement",
+      "--talk-name=org.freedesktop.ScreenSaver",
+      "--own-name=org.mpris.MediaPlayer2.mpv",
+      "--system-talk-name=org.freedesktop.login1"
   ],
   "modules": [
-    {
-      "name": "jellyfin-media-player",
-      "buildsystem": "cmake-ninja",
-      "config-opts": [
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DQTROOT=/usr",
-        "-DOpenGL_GL_PREFERENCE=GLVND"
-      ],
-      "post-install": [
-        "install -Dm644 resources/meta/com.github.iwalton3.jellyfin-media-player.desktop /app/share/applications/com.github.iwalton3.jellyfin-media-player.desktop",
-        "install -Dm644 resources/images/icon.png /app/share/icons/hicolor/256x256/apps/com.github.iwalton3.jellyfin-media-player.png",
-        "install -Dm644 resources/images/icon.svg /app/share/icons/hicolor/scalable/apps/com.github.iwalton3.jellyfin-media-player.svg",
-        "install -Dm644 resources/meta/com.github.iwalton3.jellyfin-media-player.appdata.xml /app/share/metainfo/com.github.iwalton3.jellyfin-media-player.appdata.xml"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://github.com/iwalton3/jellyfin-media-player.git",
-          "commit": "64af220dadc4bf6afc91089a929ea3cd4403600b"
-        }
-      ],
-      "modules": [
-        {
-          "name": "mpv",
-          "buildsystem": "meson",
+      {
+          "name": "jellyfin-media-player",
+          "buildsystem": "cmake-ninja",
           "config-opts": [
-            "-Dlibmpv=true",
-            "-Dcplayer=false",
-            "-Dbuild-date=false",
-            "-Dmanpage-build=disabled",
-            "-Dvaapi=enabled",
-            "-Dcuda-hwaccel=enabled",
-            "-Dpulse=enabled",
-            "-Dalsa=enabled",
-            "-Duchardet=enabled"
+              "-DCMAKE_BUILD_TYPE=Release",
+              "-DQTROOT=/usr",
+              "-DOpenGL_GL_PREFERENCE=GLVND"
           ],
-          "cleanup": [
-            "/lib/pkgconfig",
-            "/share",
-            "/include"
+          "post-install": [
+              "install -Dm644 resources/meta/com.github.iwalton3.jellyfin-media-player.desktop /app/share/applications/com.github.iwalton3.jellyfin-media-player.desktop",
+              "install -Dm644 resources/images/icon.png /app/share/icons/hicolor/256x256/apps/com.github.iwalton3.jellyfin-media-player.png",
+              "install -Dm644 resources/images/icon.svg /app/share/icons/hicolor/scalable/apps/com.github.iwalton3.jellyfin-media-player.svg",
+              "install -Dm644 resources/meta/com.github.iwalton3.jellyfin-media-player.appdata.xml /app/share/metainfo/com.github.iwalton3.jellyfin-media-player.appdata.xml"
           ],
           "sources": [
-            {
-              "type": "git",
-              "url": "https://github.com/mpv-player/mpv.git",
-              "tag": "v0.38.0",
-              "commit": "02254b92dd237f03aa0a151c2a68778c4ea848f9",
-              "x-checker-data": {
-                "type": "git",
-                "tag-pattern": "^v([\\d.]+)$"
+              {
+                  "type": "git",
+                  "url": "https://github.com/iwalton3/jellyfin-media-player.git",
+                  "tag": "v1.11.1",
+                  "commit": "64af220dadc4bf6afc91089a929ea3cd4403600b",
+                  "x-checker-data": {
+                      "type": "git",
+                      "tag-pattern": "^v([\\d.]+)$"
+                  }
               }
-            }
           ],
           "modules": [
-            {
-              "name": "ffnvcodec",
-              "buildsystem": "simple",
-              "build-commands": [
-                "make install PREFIX=/app"
-              ],
-              "cleanup": [
-                "/lib/pkgconfig",
-                "/include"
-              ],
-              "sources": [
-                {
-                  "type": "git",
-                  "url": "https://github.com/FFmpeg/nv-codec-headers.git",
-                  "tag": "n12.2.72.0",
-                  "commit": "c69278340ab1d5559c7d7bf0edf615dc33ddbba7",
-                  "x-checker-data": {
-                    "type": "git",
-                    "tag-pattern": "^n([\\d.]+)$"
-                  }
-                }
-              ]
-            },
-            {
-              "name": "ffmpeg",
-              "config-opts": [
-                "--enable-shared",
-                "--disable-static",
-                "--enable-gnutls",
-                "--enable-pic",
-                "--disable-doc",
-                "--disable-programs",
-                "--disable-encoders",
-                "--disable-muxers",
-                "--disable-devices",
-                "--enable-vaapi",
-                "--enable-cuvid",
-                "--enable-libdav1d",
-                "--enable-gpl"
-              ],
-              "cleanup": [
-                "/lib/pkgconfig",
-                "/share",
-                "/include"
-              ],
-              "sources": [
-                {
-                  "type": "git",
-                  "url": "https://github.com/FFmpeg/FFmpeg.git",
-                  "tag": "n7.0.2",
-                  "commit": "e3a61e91030696348b56361bdf80ea358aef4a19",
-                  "x-checker-data": {
-                    "type": "git",
-                    "tag-pattern": "^n([\\d.]+)$"
-                  }
-                }
-              ]
-            },
-            "shared-modules/luajit/luajit.json",
-            {
-              "name": "libass",
-              "config-opts": [
-                "--enable-shared",
-                "--disable-static"
-              ],
-              "cleanup": [
-                "/lib/*.la",
-                "/lib/pkgconfig",
-                "/include"
-              ],
-              "sources": [
-                {
-                  "type": "git",
-                  "url": "https://github.com/libass/libass.git",
-                  "tag": "0.17.3",
-                  "commit": "e46aedea0a0d17da4c4ef49d84b94a7994664ab5",
-                  "x-checker-data": {
-                    "type": "git",
-                    "tag-pattern": "^([\\d.]+)$"
-                  }
-                }
-              ]
-            },
-            {
-              "name": "uchardet",
-              "buildsystem": "cmake-ninja",
-              "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INSTALL_LIBDIR=lib",
-                "-DBUILD_BINARY=OFF"
-              ],
-              "cleanup": [
-                "/lib/*.a",
-                "/lib/pkgconfig",
-                "/share",
-                "/include"
-              ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz",
-                  "sha256": "e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0",
-                  "x-checker-data": {
-                    "type": "html",
-                    "url": "https://www.freedesktop.org/software/uchardet/releases/",
-                    "version-pattern": "uchardet-(\\d+\\.\\d+\\.\\d+)\\.tar\\.xz",
-                    "url-template": "https://www.freedesktop.org/software/uchardet/releases/uchardet-$version.tar.xz"
-                  }
-                }
-              ]
-            },
-            {
-              "name": "libplacebo",
-              "buildsystem": "meson",
-              "config-opts": [
-                "-Dvulkan=enabled",
-                "-Dshaderc=enabled"
-              ],
-              "cleanup": [
-                "/include",
-                "/lib/pkgconfig"
-              ],
-              "sources": [
-                {
-                  "type": "git",
-                  "url": "https://code.videolan.org/videolan/libplacebo.git",
-                  "tag": "v7.349.0",
-                  "commit": "1fd3c7bde7b943fe8985c893310b5269a09b46c5",
-                  "x-checker-data": {
-                    "type": "git",
-                    "tag-pattern": "^v([\\d.]+)$"
-                  }
-                }
-              ],
-              "modules": [
-                {
-                  "name": "shaderc",
-                  "buildsystem": "cmake-ninja",
-                  "builddir": true,
+              {
+                  "name": "mpv",
+                  "buildsystem": "meson",
                   "config-opts": [
-                    "-DSHADERC_SKIP_COPYRIGHT_CHECK=ON",
-                    "-DSHADERC_SKIP_EXAMPLES=ON",
-                    "-DSHADERC_SKIP_TESTS=ON",
-                    "-DSPIRV_SKIP_EXECUTABLES=ON",
-                    "-DENABLE_GLSLANG_BINARIES=OFF",
-                    "-DCMAKE_BUILD_TYPE=Release"
+                      "-Dlibmpv=true",
+                      "-Dcplayer=false",
+                      "-Dbuild-date=false",
+                      "-Dmanpage-build=disabled",
+                      "-Dvaapi=enabled",
+                      "-Dcuda-hwaccel=enabled",
+                      "-Dpulse=enabled",
+                      "-Dalsa=enabled",
+                      "-Duchardet=enabled"
                   ],
                   "cleanup": [
-                    "/bin",
-                    "/include",
-                    "/lib/*.a",
-                    "/lib/cmake",
-                    "/lib/pkgconfig"
+                      "/lib/pkgconfig",
+                      "/share",
+                      "/include"
                   ],
                   "sources": [
-                    {
-                      "type": "git",
-                      "url": "https://github.com/google/shaderc.git",
-                      "tag": "v2024.2",
-                      "commit": "3ac03b8ad85a8e328a6182cddee8d05810bd5a2c",
-                      "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
+                      {
+                          "type": "git",
+                          "url": "https://github.com/mpv-player/mpv.git",
+                          "tag": "v0.39.0",
+                          "commit": "a0fba7be57f3822d967b04f0f6b6d6341e7516e7",
+                          "x-checker-data": {
+                              "type": "git",
+                              "tag-pattern": "^v([\\d.]+)$"
+                          }
                       }
-                    },
-                    {
-                      "type": "git",
-                      "url": "https://github.com/KhronosGroup/SPIRV-Tools.git",
-                      "tag": "v2023.2",
-                      "commit": "44d72a9b36702f093dd20815561a56778b2d181e",
-                      "dest": "third_party/spirv-tools"
-                    },
-                    {
-                      "type": "git",
-                      "url": "https://github.com/KhronosGroup/SPIRV-Headers.git",
-                      "tag": "sdk-1.3.250.1",
-                      "commit": "268a061764ee69f09a477a695bf6a11ffe311b8d",
-                      "dest": "third_party/spirv-headers"
-                    },
-                    {
-                      "type": "git",
-                      "url": "https://github.com/KhronosGroup/glslang.git",
-                      "tag": "14.3.0",
-                      "commit": "fa9c3deb49e035a8abcabe366f26aac010f6cbfb",
-                      "dest": "third_party/glslang",
-                      "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^([\\d.]+)$"
+                  ],
+                  "modules": [
+                      {
+                          "name": "ffnvcodec",
+                          "buildsystem": "simple",
+                          "build-commands": [
+                              "make install PREFIX=/app"
+                          ],
+                          "cleanup": [
+                              "/lib/pkgconfig",
+                              "/include"
+                          ],
+                          "sources": [
+                              {
+                                  "type": "git",
+                                  "url": "https://github.com/FFmpeg/nv-codec-headers.git",
+                                  "tag": "n12.2.72.0",
+                                  "commit": "c69278340ab1d5559c7d7bf0edf615dc33ddbba7",
+                                  "x-checker-data": {
+                                      "type": "git",
+                                      "tag-pattern": "^n([\\d.]+)$"
+                                  }
+                              }
+                          ]
+                      },
+                      "shared-modules/luajit/luajit.json",
+                      {
+                          "name": "libass",
+                          "config-opts": [
+                              "--enable-shared",
+                              "--disable-static"
+                          ],
+                          "cleanup": [
+                              "/lib/*.la",
+                              "/lib/pkgconfig",
+                              "/include"
+                          ],
+                          "sources": [
+                              {
+                                  "type": "git",
+                                  "url": "https://github.com/libass/libass.git",
+                                  "tag": "0.17.3",
+                                  "commit": "e46aedea0a0d17da4c4ef49d84b94a7994664ab5",
+                                  "x-checker-data": {
+                                      "type": "git",
+                                      "tag-pattern": "^([\\d.]+)$"
+                                  }
+                              }
+                          ]
+                      },
+                      {
+                          "name": "uchardet",
+                          "buildsystem": "cmake-ninja",
+                          "config-opts": [
+                              "-DCMAKE_BUILD_TYPE=Release",
+                              "-DCMAKE_INSTALL_LIBDIR=lib",
+                              "-DBUILD_BINARY=OFF"
+                          ],
+                          "cleanup": [
+                              "/lib/*.a",
+                              "/lib/pkgconfig",
+                              "/share",
+                              "/include"
+                          ],
+                          "sources": [
+                              {
+                                  "type": "archive",
+                                  "url": "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz",
+                                  "sha256": "e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0",
+                                  "x-checker-data": {
+                                      "type": "html",
+                                      "url": "https://www.freedesktop.org/software/uchardet/releases/",
+                                      "version-pattern": "uchardet-(\\d+\\.\\d+\\.\\d+)\\.tar\\.xz",
+                                      "url-template": "https://www.freedesktop.org/software/uchardet/releases/uchardet-$version.tar.xz"
+                                  }
+                              }
+                          ]
+                      },
+                      {
+                          "name": "libplacebo",
+                          "buildsystem": "meson",
+                          "config-opts": [
+                              "-Dvulkan=enabled",
+                              "-Dshaderc=enabled"
+                          ],
+                          "cleanup": [
+                              "/include",
+                              "/lib/pkgconfig"
+                          ],
+                          "sources": [
+                              {
+                                  "type": "git",
+                                  "url": "https://code.videolan.org/videolan/libplacebo.git",
+                                  "tag": "v7.349.0",
+                                  "commit": "1fd3c7bde7b943fe8985c893310b5269a09b46c5",
+                                  "x-checker-data": {
+                                      "type": "git",
+                                      "tag-pattern": "^v([\\d.]+)$"
+                                  }
+                              }
+                          ]
                       }
-                    }
                   ]
-                }
-              ]
-            }
+              }
           ]
-        }
-      ]
-    }
+      }
   ]
 }


### PR DESCRIPTION
`shaderc`is part of the runtime now and can be removed
Use ffmpeg from the runtime extension
Update mpv
Add tag and x-checker-data to jellyfin source