### PR TITLE
Update runtime to 5.15-25.08, update modules

### DIFF
--- a/com.github.iwalton3.jellyfin-media-player.json
+++ b/com.github.iwalton3.jellyfin-media-player.json
@@ -1,21 +1,11 @@
 {
   "app-id": "com.github.iwalton3.jellyfin-media-player",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15-24.08",
+  "runtime-version": "5.15-25.08",
   "sdk": "org.kde.Sdk",
   "base": "io.qt.qtwebengine.BaseApp",
-  "base-version": "5.15-24.08",
+  "base-version": "5.15-25.08",
   "command": "jellyfinmediaplayer",
-  "add-extensions": {
-    "org.freedesktop.Platform.ffmpeg-full": {
-      "directory": "lib/ffmpeg",
-      "version": "24.08",
-      "add-ld-path": "."
-    }
-  },
-  "cleanup-commands": [
-    "mkdir -p /app/lib/ffmpeg"
-  ],
   "finish-args": [
     "--socket=wayland",
     "--socket=fallback-x11",
@@ -48,7 +38,10 @@
           "type": "git",
           "url": "https://github.com/iwalton3/jellyfin-media-player.git",
           "commit": "41ba4348addd46b806ba7bd1a0c92b457ae5ed7c"
-        }
+        },
+        {
+          "type": "patch",
+          "path": "jellyfin-fix-cmake-4.patch"}
       ],
       "modules": [
         {
@@ -74,8 +67,8 @@
             {
               "type": "git",
               "url": "https://github.com/mpv-player/mpv.git",
-              "tag": "v0.39.0",
-              "commit": "a0fba7be57f3822d967b04f0f6b6d6341e7516e7",
+              "tag": "v0.40.0",
+              "commit": "e48ac7ce08462f5e33af6ef9deeac6fa87eef01e",
               "x-checker-data": {
                 "type": "git",
                 "tag-pattern": "^v([\\d.]+)$"
@@ -83,29 +76,6 @@
             }
           ],
           "modules": [
-            {
-              "name": "ffnvcodec",
-              "buildsystem": "simple",
-              "build-commands": [
-                "make install PREFIX=/app"
-              ],
-              "cleanup": [
-                "/lib/pkgconfig",
-                "/include"
-              ],
-              "sources": [
-                {
-                  "type": "git",
-                  "url": "https://github.com/FFmpeg/nv-codec-headers.git",
-                  "tag": "n13.0.19.0",
-                  "commit": "e844e5b26f46bb77479f063029595293aa8f812d",
-                  "x-checker-data": {
-                    "type": "git",
-                    "tag-pattern": "^n([\\d.]+)$"
-                  }
-                }
-              ]
-            },
             "shared-modules/luajit/luajit.json",
             {
               "name": "libass",
@@ -122,8 +92,8 @@
                 {
                   "type": "git",
                   "url": "https://github.com/libass/libass.git",
-                  "tag": "0.17.3",
-                  "commit": "e46aedea0a0d17da4c4ef49d84b94a7994664ab5",
+                  "tag": "0.17.4",
+                  "commit": "bbb3c7f1570a4a021e52683f3fbdf74fe492ae84",
                   "x-checker-data": {
                     "type": "git",
                     "tag-pattern": "^([\\d.]+)$"
@@ -137,7 +107,8 @@
               "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_INSTALL_LIBDIR=lib",
-                "-DBUILD_BINARY=OFF"
+                "-DBUILD_BINARY=OFF",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
               ],
               "cleanup": [
                 "/lib/*.a",
@@ -171,13 +142,16 @@
                 {
                   "type": "git",
                   "url": "https://code.videolan.org/videolan/libplacebo.git",
-                  "tag": "v7.349.0",
-                  "commit": "1fd3c7bde7b943fe8985c893310b5269a09b46c5",
+                  "tag": "v7.351.0",
+                  "commit": "3188549fba13bbdf3a5a98de2a38c2e71f04e21e",
                   "x-checker-data": {
                     "type": "git",
                     "tag-pattern": "^v([\\d.]+)$"
                   }
-                }
+                },
+                {
+                  "type": "patch",
+                  "path": "libplacebo-vulkan-python-xml.patch"}
               ]
             }
           ]

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "The application is offered as org.jellyfin.JellyfinDesktop now",
+  "end-of-life-rebase": "org.jellyfin.JellyfinDesktop"
+}

--- a/jellyfin-fix-cmake-4.patch
+++ b/jellyfin-fix-cmake-4.patch
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1817775..52b98a3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,7 +41,6 @@ endmacro()
+ set_policy(CMP0020 NEW)
+ set_policy(CMP0017 NEW)
+ set_policy(CMP0058 NEW)
+-set_policy(CMP0026 OLD)
+ set_policy(CMP0071 NEW)
+ set_policy(CMP0072 NEW)
+ set_policy(CMP0148 OLD)
+diff --git a/CMakeModules/utils.cmake b/CMakeModules/utils.cmake
+index 0b129e9..db83e26 100644
+--- a/CMakeModules/utils.cmake
++++ b/CMakeModules/utils.cmake
+@@ -17,20 +17,22 @@ function(copy_resources target)
+   
+   get_property(RESOURCE_LIST GLOBAL PROPERTY _${target}_RESOURCE_LIST)
+ 
+-  # we read the LOCATION from the target instead of using a generator
+-  # here since add_custom_command doesn't support generator expresessions
+-  # in the output field, and this is still cleaner than hardcoding the path
+-  # of the output binary.
+-  #  
+-  get_property(TARGET_LOC TARGET ${target} PROPERTY LOCATION)
+-  get_filename_component(TARGET_DIR ${TARGET_LOC} DIRECTORY)
+-  if(APPLE)
+-    set(TARGET_LOC ${TARGET_DIR}/..)
+-  else()
+-    set(TARGET_LOC ${TARGET_DIR})
+-  endif()
+-  
+   if(RESOURCE_LIST)
++    set_policy(CMP0026 OLD)
++
++    # we read the LOCATION from the target instead of using a generator
++    # here since add_custom_command doesn't support generator expresessions
++    # in the output field, and this is still cleaner than hardcoding the path
++    # of the output binary.
++    #
++    get_property(TARGET_LOC TARGET ${target} PROPERTY LOCATION)
++    get_filename_component(TARGET_DIR ${TARGET_LOC} DIRECTORY)
++    if(APPLE)
++      set(TARGET_LOC ${TARGET_DIR}/..)
++    else()
++      set(TARGET_LOC ${TARGET_DIR})
++    endif()
++
+     foreach(RF ${RESOURCE_LIST})
+       string(REPLACE "|" ";" PARTS "${RF}")
+       list(GET PARTS 0 SOURCE_FILE)

--- a/libplacebo-vulkan-python-xml.patch
+++ b/libplacebo-vulkan-python-xml.patch
@@ -1,0 +1,16 @@
+Formerly only needed with python-3.14.x but backports have broke
+this with python-3.13.6 too.
+
+https://bugs.gentoo.org/960115
+https://bugs.gentoo.org/961230
+https://code.videolan.org/videolan/libplacebo/-/commit/12509c0f1ee8
+--- a/src/vulkan/utils_gen.py
++++ b/src/vulkan/utils_gen.py
+@@ -203,5 +203,6 @@
+         xmlfile = find_registry_xml(datadir)
+ 
+-    registry = VkXML(ET.parse(xmlfile))
++    tree = ET.parse(xmlfile)
++    registry = VkXML(tree.getroot())
+     with open(outfile, 'w') as f:
+         f.write(TEMPLATE.render(


### PR DESCRIPTION
FFmpeg-full is in the runtime now and can be removed.

nv-codec-headers are in the runtime and can be removed.